### PR TITLE
Add upload command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,8 +161,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
 name = "cmake"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,7 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
->>>>>>> Reference uploader
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +273,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -413,6 +420,19 @@ name = "libc"
 version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "cmake",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -602,9 +622,12 @@ dependencies = [
  "ck3save",
  "directories",
  "eu4save",
+ "fern",
+ "flate2",
  "hoi4save",
  "imperator-save",
  "jomini",
+ "log",
  "memmap",
  "native-tls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781f336cc9826dbaddb9754cb5db61e64cab4f69668bd19dcc4a0394a86f4cb1"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "assert_cmd"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +78,8 @@ dependencies = [
  "log",
  "native-tls",
  "openssl",
+ "serde",
+ "serde_json",
  "url",
  "wildmatch",
 ]
@@ -77,10 +91,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "bstr"
@@ -130,6 +161,24 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+>>>>>>> Reference uploader
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +204,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "directories"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "doc-comment"
@@ -223,13 +303,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -507,13 +598,17 @@ dependencies = [
  "argh",
  "assert_cmd",
  "attohttpc",
+ "base64",
  "ck3save",
+ "directories",
  "eu4save",
  "hoi4save",
  "imperator-save",
  "jomini",
  "memmap",
  "native-tls",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -544,7 +639,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -558,11 +653,28 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
 ]
 
 [[package]]
@@ -582,6 +694,24 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schannel"
@@ -637,6 +767,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,7 +797,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi",
 ]
@@ -675,6 +816,15 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "treeline"
@@ -754,6 +904,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,16 @@ hoi4save = "0.1"
 argh = "0.1"
 memmap = "0.7"
 anyhow = "1"
+flate2 = { version = "1", features = ["zlib-ng-compat"], default-features = false }
+attohttpc = { version = "0.16", features = ["json"] }
+native-tls = { version = "0.2", features = ["vendored"] }
+serde = { version = "1",   features = ["derive"] }
+toml = "0.5"
+directories = "3"
+base64 = "0.13"
 
 [dev-dependencies]
-attohttpc = "0.16"
 assert_cmd = "1"
-native-tls = { version = "0.2", features = ["vendored"] }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ serde = { version = "1",   features = ["derive"] }
 toml = "0.5"
 directories = "3"
 base64 = "0.13"
+fern = "0.6"
+log = "0.4"
+
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ struct RakalyCommand {
 #[argh(subcommand)]
 enum GameCommand {
     Melt(crate::melt::MeltCommand),
+    Upload(crate::upload::UploadCommand),
 }
 
 pub fn run() -> anyhow::Result<i32> {
@@ -25,6 +26,7 @@ pub fn run() -> anyhow::Result<i32> {
     } else if let Some(cmd) = args.cmd {
         match cmd {
             GameCommand::Melt(melt) => melt.exec(),
+            GameCommand::Upload(upload) => upload.exec(),
         }
     } else {
         println!("execute --help to see available options");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,41 @@
+use anyhow::Context;
+use directories::ProjectDirs;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Deserialize)]
+pub struct RakalyConfig {
+    pub user: String,
+    pub api_key: String,
+
+    #[serde(default = "default_base_url")]
+    pub base_url: String,
+}
+
+pub fn default_base_url() -> String {
+    String::from("https://rakaly.com")
+}
+
+pub fn read_config<P: AsRef<Path>>(location: P) -> anyhow::Result<RakalyConfig> {
+    let path = location.as_ref();
+    let config_data =
+        std::fs::read(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let config = parse_config(&config_data)
+        .with_context(|| format!("Malformatted config file: {}", path.display()))?;
+    Ok(config)
+}
+
+pub fn parse_config(data: &[u8]) -> anyhow::Result<RakalyConfig> {
+    toml::de::from_slice(data).context("unable to deserialize toml config")
+}
+
+pub fn default_config_path() -> Option<PathBuf> {
+    if let Some(proj_dirs) = ProjectDirs::from("com", "Rakaly", "Rakaly") {
+        let default_path = proj_dirs.config_dir().join("config.toml");
+        if default_path.exists() {
+            return Some(default_path);
+        }
+    }
+
+    None
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,16 @@
-pub fn configure_logger() -> anyhow::Result<()> {
+use anyhow::bail;
+
+pub fn configure_logger(level: u8) -> anyhow::Result<()> {
+    let log_level = match level {
+        0 => log::LevelFilter::Off,
+        1 => log::LevelFilter::Error,
+        2 => log::LevelFilter::Warn,
+        3 => log::LevelFilter::Info,
+        4 => log::LevelFilter::Debug,
+        5 => log::LevelFilter::Trace,
+        _ => bail!("unrecognized log level"),
+    };
+
     fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(
@@ -8,7 +20,7 @@ pub fn configure_logger() -> anyhow::Result<()> {
                 message
             ))
         })
-        .level(log::LevelFilter::Debug)
+        .level(log_level)
         .chain(std::io::stdout())
         .apply()?;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -2,12 +2,10 @@ use anyhow::bail;
 
 pub fn configure_logger(level: u8) -> anyhow::Result<()> {
     let log_level = match level {
-        0 => log::LevelFilter::Off,
-        1 => log::LevelFilter::Error,
-        2 => log::LevelFilter::Warn,
-        3 => log::LevelFilter::Info,
-        4 => log::LevelFilter::Debug,
-        5 => log::LevelFilter::Trace,
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        3 => log::LevelFilter::Trace,
         _ => bail!("unrecognized log level"),
     };
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,16 @@
+pub fn configure_logger() -> anyhow::Result<()> {
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{}][{}] {}",
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .level(log::LevelFilter::Debug)
+        .chain(std::io::stdout())
+        .apply()?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 mod cli;
+mod config;
 mod melt;
+mod upload;
+mod upload_client;
 
 fn main() {
     std::process::exit(match cli::run() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod melt;
 mod upload;
 mod upload_client;
+mod log;
 
 fn main() {
     std::process::exit(match cli::run() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod cli;
 mod config;
+mod log;
 mod melt;
 mod upload;
 mod upload_client;
-mod log;
 
 fn main() {
     std::process::exit(match cli::run() {

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,7 +1,4 @@
-use crate::{
-    config::{default_base_url, default_config_path, read_config},
-    upload_client::UploadClient,
-};
+use crate::{config::{default_base_url, default_config_path, read_config}, log::configure_logger, upload_client::UploadClient};
 use anyhow::anyhow;
 use argh::FromArgs;
 use std::path::PathBuf;
@@ -29,6 +26,8 @@ pub(crate) struct UploadCommand {
 
 impl UploadCommand {
     pub(crate) fn exec(&self) -> anyhow::Result<i32> {
+        configure_logger()?;
+
         let config = self.config.clone().or_else(default_config_path);
         let config = config.map(read_config).transpose()?;
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -19,6 +19,10 @@ pub(crate) struct UploadCommand {
     #[argh(option, short = 'c')]
     config: Option<PathBuf>,
 
+    /// increase the verbosity of the command.
+    #[argh(switch, short = 'v')]
+    verbose: u8,
+
     /// file to upload
     #[argh(positional)]
     file: PathBuf,
@@ -26,9 +30,10 @@ pub(crate) struct UploadCommand {
 
 impl UploadCommand {
     pub(crate) fn exec(&self) -> anyhow::Result<i32> {
-        configure_logger()?;
+        configure_logger(self.verbose)?;
 
         let config = self.config.clone().or_else(default_config_path);
+        log::debug!("rakaly config file path: {:?}", config);
         let config = config.map(read_config).transpose()?;
 
         let user = self

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,4 +1,8 @@
-use crate::{config::{default_base_url, default_config_path, read_config}, log::configure_logger, upload_client::UploadClient};
+use crate::{
+    config::{default_base_url, default_config_path, read_config},
+    log::configure_logger,
+    upload_client::UploadClient,
+};
 use anyhow::anyhow;
 use argh::FromArgs;
 use std::path::PathBuf;

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,0 +1,66 @@
+use crate::{
+    config::{default_base_url, default_config_path, read_config},
+    upload_client::UploadClient,
+};
+use anyhow::anyhow;
+use argh::FromArgs;
+use std::path::PathBuf;
+
+/// Upload a save file to Rakaly
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "upload")]
+pub(crate) struct UploadCommand {
+    /// rakaly user id
+    #[argh(option, short = 'u')]
+    user: Option<String>,
+
+    /// rakaly api key
+    #[argh(option)]
+    api_key: Option<String>,
+
+    /// path to rakaly config
+    #[argh(option, short = 'c')]
+    config: Option<PathBuf>,
+
+    /// file to upload
+    #[argh(positional)]
+    file: PathBuf,
+}
+
+impl UploadCommand {
+    pub(crate) fn exec(&self) -> anyhow::Result<i32> {
+        let config = self.config.clone().or_else(default_config_path);
+        let config = config.map(read_config).transpose()?;
+
+        let user = self
+            .user
+            .as_deref()
+            .or_else(|| config.as_ref().map(|x| x.user.as_str()));
+
+        let api_key = self
+            .api_key
+            .as_deref()
+            .or_else(|| config.as_ref().map(|x| x.api_key.as_str()));
+
+        let base_url = config
+            .as_ref()
+            .map(|x| x.base_url.clone())
+            .unwrap_or_else(default_base_url);
+
+        let user = user.ok_or_else(|| anyhow!("user must be supplied via cli or config"))?;
+        let api_key =
+            api_key.ok_or_else(|| anyhow!("api_key must be supplied via cli or config"))?;
+
+        let client = UploadClient {
+            user,
+            api_key,
+            base_url: base_url.as_str(),
+        };
+
+        let path = self.file.as_path();
+        let new_save_id = client.upload(path)?;
+        println!("{}", &new_save_id.save_id);
+        println!("{}/eu4/saves/{}", &base_url, &new_save_id.save_id);
+        Ok(0)
+    }
+}

--- a/src/upload_client.rs
+++ b/src/upload_client.rs
@@ -36,7 +36,7 @@ impl<'a> UploadClient<'a> {
     fn upload_zip(&self, path: &Path) -> anyhow::Result<NewSave> {
         let file = File::open(path).context("unable to open")?;
         let now = Instant::now();
-        let resp = attohttpc::post(format!("{}/{}", self.base_url, "/api/saves"))
+        let resp = attohttpc::post(format!("{}/{}", self.base_url, "api/saves"))
             .header(AUTHORIZATION, self.format_basic_auth())
             .header(CONTENT_TYPE, "application/zip")
             .file(file)
@@ -70,7 +70,7 @@ impl<'a> UploadClient<'a> {
         );
 
         let now = Instant::now();
-        let resp = attohttpc::post(format!("{}/{}", self.base_url, "/api/saves"))
+        let resp = attohttpc::post(format!("{}/{}", self.base_url, "api/saves"))
             .header(AUTHORIZATION, self.format_basic_auth())
             .header(CONTENT_ENCODING, "gzip")
             .bytes(buffer.as_slice())

--- a/src/upload_client.rs
+++ b/src/upload_client.rs
@@ -1,0 +1,114 @@
+use anyhow::{anyhow, bail, Context};
+use attohttpc::header::{AUTHORIZATION, CONTENT_ENCODING, CONTENT_TYPE};
+use flate2::{bufread::GzEncoder, Compression};
+use serde::Deserialize;
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+    time::Instant,
+};
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct NewSave {
+    pub save_id: String,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct RakalyError {
+    pub name: String,
+    pub msg: String,
+}
+
+#[derive(Debug)]
+pub struct UploadClient<'a> {
+    pub user: &'a str,
+    pub api_key: &'a str,
+    pub base_url: &'a str,
+}
+
+impl<'a> UploadClient<'a> {
+    fn format_basic_auth(&self) -> String {
+        let auth = format!("{}:{}", self.user, self.api_key);
+        format!("Basic {}", base64::encode(&auth))
+    }
+
+    fn upload_zip(&self, path: &Path) -> anyhow::Result<NewSave> {
+        let file = File::open(path).context("unable to open")?;
+        let now = Instant::now();
+        let resp = attohttpc::post(format!("{}/{}", self.base_url, "/api/saves"))
+            .header(AUTHORIZATION, self.format_basic_auth())
+            .header(CONTENT_TYPE, "application/zip")
+            .file(file)
+            .send()?;
+        println!("uploaded in {}ms", now.elapsed().as_millis());
+
+        if resp.is_success() {
+            let save_id = resp.json()?;
+            Ok(save_id)
+        } else {
+            let error: RakalyError = resp.json()?;
+            bail!("server returned an error: {} : {}", error.name, error.msg)
+        }
+    }
+
+    fn upload_txt(&self, path: &Path) -> anyhow::Result<NewSave> {
+        let file = File::open(path).context("unable to open")?;
+        let meta = file.metadata().context("unable to get metadata")?;
+
+        let reader = BufReader::new(file);
+        let mut buffer = Vec::new();
+
+        let now = Instant::now();
+        let mut gz = GzEncoder::new(reader, Compression::new(4));
+        gz.read_to_end(&mut buffer).context("unable to compress")?;
+        println!(
+            "compressed {} bytes to {} in {}ms",
+            meta.len(),
+            buffer.len(),
+            now.elapsed().as_millis()
+        );
+
+        let now = Instant::now();
+        let resp = attohttpc::post(format!("{}/{}", self.base_url, "/api/saves"))
+            .header(AUTHORIZATION, self.format_basic_auth())
+            .header(CONTENT_ENCODING, "gzip")
+            .bytes(buffer.as_slice())
+            .send()?;
+        println!("uploaded in {}ms", now.elapsed().as_millis());
+
+        if resp.is_success() {
+            let save_id = resp.json()?;
+            Ok(save_id)
+        } else {
+            let error: RakalyError = resp.json()?;
+            bail!("server returned an error: {} : {}", error.name, error.msg)
+        }
+    }
+
+    pub fn upload(&self, path: &Path) -> anyhow::Result<NewSave> {
+        let path_display = path.display();
+        let magic = {
+            let mut buffer = [0; 4];
+            let mut file =
+                File::open(path).with_context(|| format!("unable to open: {}", path_display))?;
+            file.read_exact(&mut buffer)
+                .with_context(|| format!("unable to read: {}", path_display))?;
+            buffer
+        };
+
+        match magic {
+            [0x50, 0x4b, 0x03, 0x04] => self
+                .upload_zip(&path)
+                .with_context(|| format!("unable to upload zip: {}", path_display)),
+            [b'E', b'U', b'4', b't'] => self
+                .upload_txt(&path)
+                .with_context(|| format!("unable to upload txt: {}", path_display)),
+            x => Err(anyhow!(
+                "unexpected file signature: {:?} - {}",
+                x,
+                path_display
+            )),
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the `rakaly upload` function which will upload a save file to
rakaly. The info needed to upload to rakaly (like username and api-key) can be
passed via cli arguments or taken from a toml config specified via the `-c`
flag or located in the user's config directory:
`C:\Users\Alice\AppData\Roaming\Rakaly\Rakaly\config\config.toml`

The config looks like:

```toml
user = "100"
api_key = "QdwzHQEdbNQxWFS8_hzTnoboVQuVZbcm"
```

This config is planned to be used for future configs.

Note that uploading plaintext saves is not yet supported in the public version
of rakaly