### PR TITLE
Update zip_next to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ directories = "5"
 base64 = "0.21"
 fern = "0.6"
 log = "0.4"
-zip_next = { version = "0.10.0", default-features = false, features = ["deflate", "zstd"] }
+zip_next = { version = "0.11.0", default-features = false, features = ["deflate", "zstd"] }
 zstd = { version = "0.13.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This version provides fixes for several bugs that were found by overhauling the fuzz tests. The interface to read archives and decompress unencrypted files remains the same.