### PR TITLE
Add watch command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -89,6 +142,12 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -132,9 +191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ck3save"
 version = "0.4.3"
-source = "git+https://github.com/rakaly/ck3save.git#865b68f05c747d6fb5eb6176f29222cca67ddf0e"
+source = "git+https://github.com/rakaly/ck3save.git#0c237ebdcba40a97d1f1b4579f6596d057de0a80"
 dependencies = [
  "flate2",
  "jomini",
@@ -142,6 +207,12 @@ dependencies = [
  "serde",
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation"
@@ -184,6 +255,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,19 +288,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "eu4save"
 version = "0.8.2"
-source = "git+https://github.com/rakaly/eu4save.git#70f242bd7f75f25cbba4cb60ac0f378ad3199bbd"
+source = "git+https://github.com/rakaly/eu4save.git#cd78368a2fc62dedf1ab8227c916e76f2c9d8aca"
 dependencies = [
  "flate2",
  "jomini",
@@ -233,6 +337,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "flate2"
@@ -273,6 +389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -479,10 +604,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e77966151130221b079bcec80f1f34a9e414fa489d99152a201c07fd2182bc"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97265751f8a9a4228476f2fc17874a9e7e70e96b893368e42619880fe143b48a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jomini"
@@ -517,6 +692,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lambert_w"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +722,17 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "libz-rs-sys"
@@ -604,6 +810,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +837,43 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.9.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num_cpus"
@@ -642,7 +897,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -701,6 +956,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -765,12 +1035,16 @@ dependencies = [
  "assert_cmd",
  "attohttpc",
  "ck3save",
+ "ctrlc",
+ "env_logger",
  "eu4save",
  "hoi4save",
  "imperator-save",
  "jomini",
+ "log",
  "memmap2",
  "native-tls",
+ "notify",
  "vic3save",
 ]
 
@@ -817,10 +1091,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f8d50ef197167638ec8912cac430639812264c455f5d861210524705af15b"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rust-fuzzy-search"
@@ -834,11 +1140,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -848,12 +1154,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -862,7 +1177,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -972,7 +1287,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1050,6 +1365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1149,6 +1480,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -1230,7 +1579,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ imperator-save = { git = "https://github.com/rakaly/imperator-save.git", default
 ck3save = { git = "https://github.com/rakaly/ck3save.git", default-features = false }
 hoi4save = { git = "https://github.com/rakaly/hoi4save.git" }
 vic3save = { git = "https://github.com/pdx-tools/pdx-tools"  }
-argh = "0.1"
-memmap2 = "0.9.5"
 anyhow = "1"
+argh = "0.1"
+ctrlc = "3.4"
+env_logger = "0.11"
+log = "0.4"
+memmap2 = "0.9.5"
+notify = "8.0.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ struct RakalyCommand {
 enum GameCommand {
     Melt(crate::melt::MeltCommand),
     Json(crate::json::JsonCommand),
+    Watch(crate::watch::WatchCommand),
 }
 
 pub fn run() -> anyhow::Result<i32> {
@@ -27,6 +28,7 @@ pub fn run() -> anyhow::Result<i32> {
         match cmd {
             GameCommand::Melt(melt) => melt.exec(),
             GameCommand::Json(json) => json.exec(),
+            GameCommand::Watch(watch) => watch.exec(),
         }
     } else {
         println!("execute --help to see available options");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod json;
 mod melt;
 mod tokens;
+mod watch;
 
 fn main() {
     std::process::exit(match cli::run() {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,484 @@
+use anyhow::{anyhow, bail, Context};
+use argh::FromArgs;
+use ck3save::PdsDate;
+use eu4save::file::{Eu4FileEntryName, Eu4FsFileKind};
+use hoi4save::file::Hoi4FsFileKind;
+use imperator_save::file::ImperatorFsFileKind;
+use jomini::TextDeserializer;
+use log::{debug, error, info, trace};
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::{
+    fmt::Display,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    time::{Duration, Instant},
+};
+use vic3save::file::Vic3FsFileKind;
+
+use crate::tokens::{
+    ck3_tokens_resolver, eu4_tokens_resolver, hoi4_tokens_resolver, imperator_tokens_resolver,
+    vic3_tokens_resolver,
+};
+
+/// Watch a save file for changes and create a copy with the save's date when changed
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "watch")]
+pub(crate) struct WatchCommand {
+    /// specify the format of the input: eu4 | ck3 | hoi4 | rome | vic3
+    /// if not specified, will be inferred from file extension
+    #[argh(option)]
+    format: Option<String>,
+
+    /// output directory for saved copies
+    /// if not specified, will use the same directory as the input file
+    #[argh(option, short = 'o')]
+    out_dir: Option<PathBuf>,
+
+    /// frequency of snapshot creation. Can be 'any' to create a snapshot on any
+    /// date change (default), 'yearly' to only create snapshots when the year
+    /// changes, or 'decade' to only create snapshots when the decade changes
+    /// (years ending in 0).
+    #[argh(option, default = "String::from(\"any\")")]
+    frequency: String,
+
+    /// file to watch for changes
+    #[argh(positional)]
+    file: PathBuf,
+}
+
+/// Frequency at which snapshots are taken
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum SnapshotFrequency {
+    /// Take a snapshot on any date change
+    AnyChange,
+    /// Take a snapshot only when the year changes
+    Yearly,
+    /// Take a snapshot only when the decade changes (year % 10 == 0)
+    Decade,
+}
+
+impl FromStr for SnapshotFrequency {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "any" | "anychange" => Ok(SnapshotFrequency::AnyChange),
+            "year" | "yearly" => Ok(SnapshotFrequency::Yearly),
+            "decade" => Ok(SnapshotFrequency::Decade),
+            _ => Err(anyhow!(
+                "Unrecognized snapshot frequency. Use 'any', 'yearly', or 'decade'"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum GameType {
+    Eu4,
+    Ck3,
+    Imperator,
+    Vic3,
+    Hoi4,
+}
+
+impl FromStr for GameType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "eu4" => Ok(GameType::Eu4),
+            "ck3" => Ok(GameType::Ck3),
+            "rome" => Ok(GameType::Imperator),
+            "hoi4" => Ok(GameType::Hoi4),
+            "v3" => Ok(GameType::Vic3),
+            _ => Err(anyhow!(
+                "Only eu4, ck3, vic3, hoi4, and imperator files supported"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GameDate {
+    year: i16,
+    month: u8,
+    day: u8,
+}
+
+impl GameDate {
+    fn decade(&self) -> i16 {
+        (self.year / 10) * 10
+    }
+
+    fn should_snapshot(
+        &self,
+        last_snapshot: Option<&GameDate>,
+        frequency: SnapshotFrequency,
+    ) -> bool {
+        match last_snapshot {
+            None => true, // Always snapshot if no previous snapshot
+            Some(last) => match frequency {
+                SnapshotFrequency::AnyChange => true, // Always snapshot on any change
+                SnapshotFrequency::Yearly => self.year != last.year,
+                SnapshotFrequency::Decade => self.decade() != last.decade(),
+            },
+        }
+    }
+}
+
+impl Display for GameDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{:02}-{:02}", self.year, self.month, self.day)
+    }
+}
+
+struct SaveInfo {
+    date: GameDate,
+}
+
+impl WatchCommand {
+    pub(crate) fn exec(&self) -> anyhow::Result<i32> {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+            .format_timestamp_secs()
+            .format_target(false)
+            .init();
+
+        info!("Starting to watch file: {}", self.file.display());
+
+        // Verify that the file exists before starting to watch
+        if !self.file.exists() {
+            bail!("File does not exist: {}", self.file.display());
+        }
+
+        // Create output directory if specified and doesn't exist
+        if let Some(out_dir) = &self.out_dir {
+            if !out_dir.exists() {
+                fs::create_dir_all(out_dir).with_context(|| {
+                    format!("Failed to create output directory: {}", out_dir.display())
+                })?;
+            }
+        }
+
+        let game_type = self.determine_game_type()?;
+
+        // Parse the snapshot frequency
+        let frequency = self.frequency.parse::<SnapshotFrequency>()?;
+        info!("Snapshot frequency: {:?}", frequency);
+
+        let path = self.file.clone();
+
+        // Get the parent directory of the file to watch
+        let parent_dir = path
+            .parent()
+            .ok_or_else(|| anyhow!("Unable to determine parent directory of {}", path.display()))?;
+
+        info!("Press Ctrl+C to stop watching");
+
+        // Create a channel to receive the events
+        let (tx, rx) = mpsc::channel();
+
+        // Create a watcher with default configuration
+        let mut watcher = RecommendedWatcher::new(
+            move |result: Result<Event, notify::Error>| {
+                if let Ok(event) = result {
+                    let _ = tx.send(event);
+                }
+            },
+            Config::default(),
+        )?;
+
+        // Start watching the parent directory for changes
+        watcher.watch(parent_dir.as_ref(), RecursiveMode::NonRecursive)?;
+
+        // Track the last snapshot date for each game
+        let mut last_snapshot: Option<GameDate> = None;
+        let mut ignore_next = false;
+
+        // Set up Ctrl+C handler with an atomic flag
+        let running = Arc::new(AtomicBool::new(true));
+        let r = running.clone();
+        ctrlc::set_handler(move || {
+            info!("Received Ctrl+C, shutting down gracefully...");
+            r.store(false, Ordering::SeqCst);
+        })
+        .context("Error setting Ctrl+C handler")?;
+
+        let debounce_timeout = Duration::from_millis(500);
+        let mut last_event: Option<EventKind> = None;
+
+        while running.load(Ordering::SeqCst) {
+            // Try to receive an event with a short timeout to allow debounce checking
+            match rx.recv_timeout(debounce_timeout) {
+                Ok(event) => {
+                    trace!("Received event: {:?}", event);
+                    let EventKind::Modify(_) = event.kind else {
+                        continue;
+                    };
+
+                    // Whenever we copy a file, we want to ignore the next event
+                    // that comes in as it will be our event
+                    if ignore_next {
+                        debug!("Ignoring event due to previous copy operation");
+                        ignore_next = false;
+                        continue;
+                    }
+
+                    last_event = Some(event.kind);
+                    continue;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    break;
+                }
+            }
+
+            if last_event.take().is_none() {
+                continue;
+            }
+
+            // Process file and create snapshots only if we're still running
+            if !running.load(Ordering::SeqCst) {
+                break;
+            }
+
+            // Measure time taken to process the file
+            let start = Instant::now();
+            let save_info = match self.process_file(&game_type) {
+                Ok(save_info) => {
+                    let duration = start.elapsed();
+                    info!(
+                        "Processed file with date: {} [{}ms]",
+                        save_info.date,
+                        duration.as_millis()
+                    );
+                    save_info
+                }
+                Err(e) => {
+                    let duration = start.elapsed();
+                    error!("Error processing file: {} [{}ms]", e, duration.as_millis());
+                    continue;
+                }
+            };
+
+            if !save_info
+                .date
+                .should_snapshot(last_snapshot.as_ref(), frequency)
+            {
+                debug!(
+                    "Skipping snapshot for date {}, waiting for next {} change",
+                    save_info.date,
+                    match frequency {
+                        SnapshotFrequency::AnyChange => "date",
+                        SnapshotFrequency::Yearly => "year",
+                        SnapshotFrequency::Decade => "decade",
+                    }
+                );
+                continue;
+            }
+
+            let out_path = self.create_output_path(&save_info.date.to_string());
+
+            // Create parent directory if it doesn't exist
+            if let Some(parent) = out_path.parent() {
+                if !parent.exists() {
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        error!("Error creating directory {}: {}", parent.display(), e);
+                        continue;
+                    }
+                }
+            }
+
+            let copy_start = Instant::now();
+            if let Err(e) = fs::copy(&self.file, &out_path) {
+                error!("Error copying file: {}", e);
+            } else {
+                let duration = copy_start.elapsed();
+                info!(
+                    "Successfully copied save to: {} [{}ms]",
+                    out_path.display(),
+                    duration.as_millis()
+                );
+                ignore_next = true;
+                last_snapshot = Some(save_info.date);
+            }
+        }
+
+        info!("Watch command completed");
+        Ok(0)
+    }
+
+    fn process_file(&self, game_type: &GameType) -> anyhow::Result<SaveInfo> {
+        let file = std::fs::File::open(&self.file)
+            .with_context(|| format!("Failed to open file: {}", self.file.display()))?;
+
+        // Parse the save to extract date (and make sure it is valid)
+        let (year, month, day) = match game_type {
+            GameType::Eu4 => {
+                let file =
+                    eu4save::Eu4File::from_file(file).context("Failed to parse EU4 save file")?;
+
+                let meta = match file.kind() {
+                    Eu4FsFileKind::Text(file) => {
+                        let reader = jomini::text::TokenReader::new(file);
+                        let mut deser = TextDeserializer::from_windows1252_reader(reader);
+                        deser.deserialize::<eu4save::models::Meta>()?
+                    }
+                    Eu4FsFileKind::Binary(eu4_binary) => eu4_binary
+                        .as_ref()
+                        .deserializer(eu4_tokens_resolver())
+                        .deserialize::<eu4save::models::Meta>()?,
+                    Eu4FsFileKind::Zip(eu4_zip) => {
+                        let mut entry = eu4_zip.get(Eu4FileEntryName::Meta)?;
+                        entry.deserialize(eu4_tokens_resolver())?
+                    }
+                };
+
+                (meta.date.year(), meta.date.month(), meta.date.day())
+            }
+            GameType::Ck3 => {
+                let mut file =
+                    ck3save::Ck3File::from_file(file).context("Failed to parse CK3 save file")?;
+
+                let meta = match file.kind_mut() {
+                    ck3save::file::Ck3FsFileKind::Text(file) => {
+                        let reader = jomini::text::TokenReader::new(file);
+                        let mut deser = TextDeserializer::from_utf8_reader(reader);
+                        deser.deserialize::<ck3save::models::Metadata>()?
+                    }
+                    ck3save::file::Ck3FsFileKind::Binary(ck3_binary) => ck3_binary
+                        .deserializer(ck3_tokens_resolver())
+                        .deserialize::<ck3save::models::Metadata>()?,
+                    ck3save::file::Ck3FsFileKind::Zip(ck3_zip) => {
+                        let mut entry =
+                            ck3_zip.meta().context("Failed to read metadata from zip")?;
+                        entry
+                            .deserializer(ck3_tokens_resolver())
+                            .deserialize::<ck3save::models::Metadata>()?
+                    }
+                };
+
+                (
+                    meta.meta_date.year(),
+                    meta.meta_date.month(),
+                    meta.meta_date.day(),
+                )
+            }
+            GameType::Imperator => {
+                let mut file = imperator_save::ImperatorFile::from_file(file)
+                    .context("Failed to parse Imperator Rome save file")?;
+
+                let meta = match file.kind_mut() {
+                    ImperatorFsFileKind::Text(file) => {
+                        let reader = jomini::text::TokenReader::new(file);
+                        let mut deser = TextDeserializer::from_utf8_reader(reader);
+                        deser.deserialize::<imperator_save::models::Metadata>()?
+                    }
+                    ImperatorFsFileKind::Binary(imperator_binary) => imperator_binary
+                        .deserializer(imperator_tokens_resolver())
+                        .deserialize::<imperator_save::models::Metadata>()?,
+                    ImperatorFsFileKind::Zip(imperator_zip) => imperator_zip
+                        .meta()
+                        .context("Failed to read metadata from zip")?
+                        .deserializer(imperator_tokens_resolver())
+                        .deserialize::<imperator_save::models::Metadata>()?,
+                };
+
+                (meta.date.year(), meta.date.month(), meta.date.day())
+            }
+            GameType::Vic3 => {
+                let mut file = vic3save::Vic3File::from_file(file)
+                    .context("Failed to parse Victoria 3 save file")?;
+
+                let meta = match file.kind_mut() {
+                    Vic3FsFileKind::Text(file) => {
+                        let reader = jomini::text::TokenReader::new(file);
+                        let mut deser = TextDeserializer::from_utf8_reader(reader);
+                        deser.deserialize::<vic3save::savefile::MetaData>()?
+                    }
+                    Vic3FsFileKind::Binary(vic3_binary) => vic3_binary
+                        .deserializer(vic3_tokens_resolver())
+                        .deserialize::<vic3save::savefile::MetaData>()?,
+                    Vic3FsFileKind::Zip(vic3_zip) => {
+                        let mut entry = vic3_zip
+                            .meta()
+                            .context("Failed to read metadata from zip")?;
+                        entry
+                            .deserializer(vic3_tokens_resolver())
+                            .deserialize::<vic3save::savefile::MetaData>()?
+                    }
+                };
+
+                (
+                    meta.game_date.year(),
+                    meta.game_date.month(),
+                    meta.game_date.day(),
+                )
+            }
+            GameType::Hoi4 => {
+                let mut file = hoi4save::Hoi4File::from_file(file)
+                    .context("Failed to parse HOI4 save file")?;
+
+                let meta = match file.kind_mut() {
+                    Hoi4FsFileKind::Text(file) => {
+                        let reader = jomini::text::TokenReader::new(file);
+                        let mut deser = TextDeserializer::from_utf8_reader(reader);
+                        deser.deserialize::<hoi4save::models::Hoi4Save>()?
+                    }
+                    Hoi4FsFileKind::Binary(hoi4_binary) => hoi4_binary
+                        .deserializer(hoi4_tokens_resolver())
+                        .deserialize::<hoi4save::models::Hoi4Save>()?,
+                };
+
+                (meta.date.year(), meta.date.month(), meta.date.day())
+            }
+        };
+
+        let game_date = GameDate { year, month, day };
+
+        Ok(SaveInfo { date: game_date })
+    }
+
+    fn determine_game_type(&self) -> anyhow::Result<GameType> {
+        if let Some(format) = &self.format {
+            return format.parse();
+        }
+
+        let extension = self
+            .file
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .ok_or_else(|| anyhow!("Could not determine file format from extension"))?;
+
+        extension
+            .parse()
+            .map_err(|_| anyhow!("Format of file unknown, please pass known format option"))
+    }
+
+    fn create_output_path(&self, date: &str) -> PathBuf {
+        let out_dir = self
+            .out_dir
+            .as_deref()
+            .unwrap_or_else(|| self.file.parent().unwrap_or_else(|| Path::new(".")));
+
+        let filename = self.file.file_stem().unwrap_or_default();
+        let extension = self.file.extension().unwrap_or_default();
+
+        let mut new_filename = filename.to_owned();
+        new_filename.push("_");
+        new_filename.push(date);
+
+        let mut path = out_dir.to_path_buf();
+        path.push(new_filename);
+
+        if !extension.is_empty() {
+            path.set_extension(extension);
+        }
+
+        path
+    }
+}


### PR DESCRIPTION
Thought it'd be fun to create a super minimal and efficient `watch` command that watches a save file for changes, and when changes do happen, extract out the date and create a copy of the file with the date in the file name. One can configure how frequently to snapshot the saves: yearly, by decade, or any change at all.

Ofc, pdxu should still remain one saves manager.