### PR TITLE
Accept vic3 format alias for save commands

### DIFF
--- a/src/melt.rs
+++ b/src/melt.rs
@@ -109,7 +109,7 @@ impl FromStr for MelterKind {
             "ck3" => Ok(MelterKind::Ck3),
             "rome" => Ok(MelterKind::Imperator),
             "hoi4" => Ok(MelterKind::Hoi4),
-            "v3" => Ok(MelterKind::Vic3),
+            "v3" | "vic3" => Ok(MelterKind::Vic3),
             _ => bail!("Only eu4, eu5, ck3, vic3, hoi4, and imperator files supported"),
         }
     }
@@ -295,5 +295,17 @@ mod tests {
             melted_path("/tmp/gamestate"),
             Path::new("/tmp").join("gamestate_melted")
         );
+    }
+
+    #[test]
+    fn vic3_format_aliases_parse() {
+        assert!(matches!(
+            "v3".parse::<MelterKind>().unwrap(),
+            MelterKind::Vic3
+        ));
+        assert!(matches!(
+            "vic3".parse::<MelterKind>().unwrap(),
+            MelterKind::Vic3
+        ));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -107,11 +107,25 @@ impl FromStr for GameType {
             "ck3" => Ok(GameType::Ck3),
             "rome" => Ok(GameType::Imperator),
             "hoi4" => Ok(GameType::Hoi4),
-            "v3" => Ok(GameType::Vic3),
+            "v3" | "vic3" => Ok(GameType::Vic3),
             _ => Err(anyhow!(
                 "Only eu4, eu5, ck3, vic3, hoi4, and imperator files supported"
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vic3_format_aliases_parse() {
+        assert!(matches!("v3".parse::<GameType>().unwrap(), GameType::Vic3));
+        assert!(matches!(
+            "vic3".parse::<GameType>().unwrap(),
+            GameType::Vic3
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

Accept `vic3` anywhere the CLI help already documents it as a valid `--format` value.

This fixes a mismatch where `melt --format vic3` and `watch --format vic3` failed during argument parsing even though the help text listed `vic3`. The existing `v3` extension spelling remains supported.

## Validation

- `rustfmt --check src/melt.rs src/watch.rs`
- `cargo test vic3_format_aliases_parse`
- `cargo test --bins`
- Local real-save smoke test: `cargo run --quiet -- melt --format vic3 --unknown-key ignore --out ... Qing_Start.v3`

Full integration tests were not run locally because this checkout does not include the private token assets that upstream CI injects.

AI assistance: implementation and PR description were materially assisted by Codex.