### PR TITLE
Make CI succeed for fork and Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       CARGO: cargo
       TARGET:
+      # Fork/Dependabot PRs don't get secrets, so this is the real test for
+      # whether we can clone the private tokens repo.
+      HAS_TOKENS_PAT: ${{ secrets.GH_PAT != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,13 +37,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # Fail loudly if a trusted build (push/tag/schedule) is missing tokens
+    # instead of shipping a binary built with empty ones.
+    - name: Require tokens for trusted builds
+      if: github.event_name != 'pull_request' && env.HAS_TOKENS_PAT != 'true'
+      shell: bash
+      run: echo "::error::GH_PAT secret missing for a trusted build" && exit 1
+
+    # Skipped without a PAT (fork/Dependabot PRs); build.rs then supplies
+    # empty token files.
     - uses: actions/checkout@v4
       name: Clone tokens
+      if: env.HAS_TOKENS_PAT == 'true'
       with:
         path: assets/
         repository: pdx-tools/tokens
         token: ${{secrets.GH_PAT}}
-        
+
     - name: Cache saves
       uses: actions/cache@v4
       with:

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     std::fs::create_dir_all("assets/tokens").expect("to create tokens directory");
-    for game in ["ck3", "hoi4", "eu4", "imperator", "vic3"] {
+    for game in ["ck3", "hoi4", "eu4", "imperator", "vic3", "eu5"] {
         let fp = format!("assets/tokens/{game}.txt");
         let p = std::path::Path::new(&fp);
         if !p.exists() {


### PR DESCRIPTION
Secrets aren't exposed to PRs from forks (or secretless same-repo PRs like Dependabot), so cloning the private tokens repo failed. Gate the clone on the secret's presence

Also add eu5 to build.rs so token-less builds compile.